### PR TITLE
Fix selector syntax warnings in Xcode 7.3

### DIFF
--- a/Distrib/DodoDistrib.swift
+++ b/Distrib/DodoDistrib.swift
@@ -2500,7 +2500,7 @@ final class MoaTimer: NSObject {
     
     self.callback = callback
     timer = NSTimer.scheduledTimerWithTimeInterval(interval, target: self,
-      selector: "timerFired:", userInfo: nil, repeats: repeats)
+      selector: #selector(MoaTimer.timerFired(_:)), userInfo: nil, repeats: repeats)
   }
   
   /// Timer is cancelled automatically when it is deallocated.
@@ -2563,7 +2563,7 @@ class OnTap: NSObject {
     super.init()
     view.addGestureRecognizer(gesture)
     view.userInteractionEnabled = true
-    gesture.addTarget(self, action: "didTap:")
+    gesture.addTarget(self, action: #selector(OnTap.didTap(_:)))
   }
 
   func didTap(gesture: UIGestureRecognizer) {
@@ -3017,8 +3017,8 @@ public final class UnderKeyboardObserver: NSObject {
   public func start() {
     stop()
     
-    notificationCenter.addObserver(self, selector: Selector("keyboardNotification:"), name:UIKeyboardWillShowNotification, object: nil);
-    notificationCenter.addObserver(self, selector: Selector("keyboardNotification:"), name:UIKeyboardWillHideNotification, object: nil);
+    notificationCenter.addObserver(self, selector: #selector(UnderKeyboardObserver.keyboardNotification(_:)), name:UIKeyboardWillShowNotification, object: nil);
+    notificationCenter.addObserver(self, selector: #selector(UnderKeyboardObserver.keyboardNotification(_:)), name:UIKeyboardWillHideNotification, object: nil);
   }
   
   /// Stop listening for keyboard notifications.

--- a/Dodo/Utils/MoaTimer.swift
+++ b/Dodo/Utils/MoaTimer.swift
@@ -35,7 +35,7 @@ final class MoaTimer: NSObject {
     
     self.callback = callback
     timer = NSTimer.scheduledTimerWithTimeInterval(interval, target: self,
-      selector: "timerFired:", userInfo: nil, repeats: repeats)
+      selector: #selector(MoaTimer.timerFired(_:)), userInfo: nil, repeats: repeats)
   }
   
   /// Timer is cancelled automatically when it is deallocated.

--- a/Dodo/Utils/OnTap.swift
+++ b/Dodo/Utils/OnTap.swift
@@ -13,7 +13,7 @@ class OnTap: NSObject {
     super.init()
     view.addGestureRecognizer(gesture)
     view.userInteractionEnabled = true
-    gesture.addTarget(self, action: "didTap:")
+    gesture.addTarget(self, action: #selector(OnTap.didTap(_:)))
   }
 
   func didTap(gesture: UIGestureRecognizer) {

--- a/Dodo/Utils/UnderKeyboardDistrib.swift
+++ b/Dodo/Utils/UnderKeyboardDistrib.swift
@@ -148,8 +148,8 @@ public final class UnderKeyboardObserver: NSObject {
   public func start() {
     stop()
     
-    notificationCenter.addObserver(self, selector: Selector("keyboardNotification:"), name:UIKeyboardWillShowNotification, object: nil);
-    notificationCenter.addObserver(self, selector: Selector("keyboardNotification:"), name:UIKeyboardWillHideNotification, object: nil);
+    notificationCenter.addObserver(self, selector: #selector(UnderKeyboardObserver.keyboardNotification(_:)), name:UIKeyboardWillShowNotification, object: nil);
+    notificationCenter.addObserver(self, selector: #selector(UnderKeyboardObserver.keyboardNotification(_:)), name:UIKeyboardWillHideNotification, object: nil);
   }
   
   /// Stop listening for keyboard notifications.


### PR DESCRIPTION
Selector syntax changed from string to #selector(className.methodName)
for better compile time analysis.
